### PR TITLE
DBD::MariaDB instead of DBD::mysql 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apk --no-cache add \
 # Install extra CPAN modules
 RUN cpanm -nv \
     DBD::Pg \
-    DBD::mysql@4.052 \
+    DBD::MariaDB@1.0 \
     Pod::Find \
     Template \
     Template::Plugin::Digest::MD5

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apk --no-cache add \
 # Install extra CPAN modules
 RUN cpanm -nv \
     DBD::Pg \
-    DBD::MariaDB@1.0 \
+    DBD::MariaDB \
     Pod::Find \
     Template \
     Template::Plugin::Digest::MD5


### PR DESCRIPTION
Sqitch changed mysql driver on 1.5.0 version, from DBD::mysql to DBD::MariaDB. 

https://metacpan.org/dist/App-Sqitch/changes

```
 - Switched the MySQL engine from DBD::mysql to DBD::MariaDB for better
   compatibility with older versions of the MySQL client library and for
   its Unicode improvements. Thanks to Mark Tyrrell for the report and
   @tiberiusferreira and Perl Monks `1nickt` and`InfiniteSilence` for the
   feedback (#825).
```

Otherwise we are getting error at runtime: 

```
DBD::MariaDB 1.0 required to manage MySQL
```

I think we should still can keep the docker image tag to same `courtapi/docker-sqitch:1.5.2`, as this should be the correct one to use. 